### PR TITLE
Add link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Koji Database SDK
 
 Connect to the Koji database
+
+# Docs can be found here: https://withkoji.com/docs/editor/database

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Connect to the Koji database
 
-# Docs can be found here: https://withkoji.com/docs/editor/database
+Docs can be found here: https://withkoji.com/docs/editor/database


### PR DESCRIPTION
I find myself exploring Github more then the developers website. It's helpful to have the docs linked for easy reference. :)