### PR TITLE
Remove JSON parse on generateSignedRequest response, handled by rp.

### DIFF
--- a/src/adapter/DatabaseAdapter.ts
+++ b/src/adapter/DatabaseAdapter.ts
@@ -378,7 +378,7 @@ export class DatabaseAdapter {
 
     try {
       const response = await rp(options);
-      const { url, signedRequest } = JSON.parse(response);
+      const { url, signedRequest } = response;
       return {
         url,
         signedRequest,


### PR DESCRIPTION
Setting `json:true` in request-promise options will return parsed data, no need to parse again.